### PR TITLE
Support files with `.yaml` extention

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,7 @@ const loadRecursive = (dir, relDir, data, vars) => {
           ? path.join(relDir, match[2].substring(1))
           : path.join(dir, match[2]);
         newRelDir = path.dirname(filePath);
-        loaded = filePath.endsWith(".yml")
+        loaded = (filePath.endsWith(".yml") || filePath.endsWith(".yaml"))
           ? yaml.safeLoad(fs.readFileSync(filePath, 'utf8'))
           // eslint-disable-next-line global-require, import/no-dynamic-require
           : require(filePath);


### PR DESCRIPTION
Current version fails with odd `Cannot find module 'src/uuid.yaml'` error if file has `.yaml` extension. Both extensions are common enough, so worth supporting?